### PR TITLE
chore: ignore agent tool scratch dirs (.serena/, .chunkhound/, .cache/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ launchSettings.json
 __pycache__
 api/index.html
 ,serverless
+
+# Agent tool scratch — per-user, never committed (linn/linn-api-development#394)
+.serena/
+.chunkhound/
+.chunkhound.json
+.cache/


### PR DESCRIPTION
Mechanical, no runtime impact — adds the agent tool-scratch ignore block to this repo's `.gitignore`.

`.serena/`, `.chunkhound/`, `.chunkhound.json` and `.cache/` are per-user agent scratch. Serena's `activate_project` runs **per submodule** (the estate has no root `.sln`), so activating it drops a `.serena/` dir into whichever tree is being worked on — and nothing here ignored it. Nothing is tracked under any of these paths in this repo, so this is prevention, not cleanup.

Part of the estate-wide rollout tracked in linn/linn-api-development#394 (28 submodules).

**No wrapper submodule-pointer bump** — this commit changes no code, so the wrapper's pin advances naturally with the next real change; bumping 28 pointers purely to record ignore rules would earn its own reviewed PR for no benefit. [Deliberate.](https://github.com/linn/linn-api-development/issues/394#issuecomment-5137843457)